### PR TITLE
[rosdep base] opensuse: tinyxml2-devel

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4346,6 +4346,7 @@ tinyxml2:
   debian: [libtinyxml2-dev]
   fedora: [tinyxml2-devel]
   gentoo: [dev-libs/tinyxml2]
+  opensuse: [tinyxml2-devel]
   ubuntu: [libtinyxml2-dev]
 tix:
   arch: [tix]


### PR DESCRIPTION
Tested with OpenSuse Tumbleweed.